### PR TITLE
Updated slot min to 1 to protect master code. Increased max to 999.

### DIFF
--- a/custom_components/nimlykoder/const.py
+++ b/custom_components/nimlykoder/const.py
@@ -15,8 +15,8 @@ CONF_OVERWRITE_PROTECTION = "overwrite_protection"
 CONF_MQTT_TOPIC = "mqtt_topic"
 
 # Defaults
-DEFAULT_SLOT_MIN = 0
-DEFAULT_SLOT_MAX = 99
+DEFAULT_SLOT_MIN = 1                    
+DEFAULT_SLOT_MAX = 999                  
 DEFAULT_RESERVED_SLOTS = [1, 2, 3]
 DEFAULT_AUTO_EXPIRE = True
 DEFAULT_CLEANUP_TIME = "03:00:00"


### PR DESCRIPTION
Min was previously set to 0, but 0 is reserved for the master code. Using this slot risks changing the master code permanently. Also, Nimly locks support up to 999 codes so I changed the max to 999.