### PR TITLE
Support for ZHA

### DIFF
--- a/custom_components/nimlykoder/__init__.py
+++ b/custom_components/nimlykoder/__init__.py
@@ -29,6 +29,7 @@ from .const import (
 )
 from .storage import NimlykoderStorage
 from .adapters.mqtt_z2m import MqttZ2mAdapter
+from .adapters.zha_doorlock import ZhaDoorLockAdapter
 from .services import async_setup_services, async_unload_services
 from .websocket import async_register_websocket_handlers
 from .panel import async_register_panel, async_unregister_panel
@@ -163,21 +164,33 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         mqtt_topic,
     )
     
+    use_zha = False
     if lock_entity:
-        # New config: derive MQTT topic from entity
-        _LOGGER.info("[async_setup_entry] Using entity selector config")
-        mqtt_topic = _get_mqtt_topic_from_entity(hass, lock_entity)
-        if not mqtt_topic:
-            _LOGGER.error(
-                "[async_setup_entry] Failed to derive MQTT topic from entity '%s'",
+        # If the lock entity was paired via ZHA, talk to it directly over
+        # the ZCL Door Lock cluster instead of deriving an MQTT topic.
+        entity_entry = er.async_get(hass).async_get(lock_entity)
+        use_zha = bool(entity_entry and entity_entry.platform == "zha")
+
+        if use_zha:
+            _LOGGER.info(
+                "[async_setup_entry] Entity '%s' is a ZHA device — using ZHA adapter",
                 lock_entity,
             )
-            return False
-        _LOGGER.info(
-            "[async_setup_entry] Derived MQTT topic '%s' from entity '%s'",
-            mqtt_topic,
-            lock_entity,
-        )
+        else:
+            # New config: derive MQTT topic from entity
+            _LOGGER.info("[async_setup_entry] Using entity selector config")
+            mqtt_topic = _get_mqtt_topic_from_entity(hass, lock_entity)
+            if not mqtt_topic:
+                _LOGGER.error(
+                    "[async_setup_entry] Failed to derive MQTT topic from entity '%s'",
+                    lock_entity,
+                )
+                return False
+            _LOGGER.info(
+                "[async_setup_entry] Derived MQTT topic '%s' from entity '%s'",
+                mqtt_topic,
+                lock_entity,
+            )
     elif mqtt_topic:
         _LOGGER.info(
             "[async_setup_entry] Using legacy MQTT topic config: %s", mqtt_topic
@@ -222,20 +235,24 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     await storage.async_load()
     _LOGGER.info("[async_setup_entry] Storage loaded with %d entries", len(storage.list_entries()))
 
-    # Initialize MQTT adapter
-    _LOGGER.debug("[async_setup_entry] Initializing MQTT adapter...")
-    mqtt_adapter = MqttZ2mAdapter(hass, config[CONF_MQTT_TOPIC])
+    # Initialize the lock communication adapter (ZHA or MQTT/Zigbee2MQTT)
+    if use_zha:
+        _LOGGER.debug("[async_setup_entry] Initializing ZHA adapter...")
+        mqtt_adapter = ZhaDoorLockAdapter(hass, lock_entity)
+    else:
+        _LOGGER.debug("[async_setup_entry] Initializing MQTT adapter...")
+        mqtt_adapter = MqttZ2mAdapter(hass, config[CONF_MQTT_TOPIC])
 
-    # Verify MQTT is available
+    # Verify the adapter can reach the lock
     mqtt_available = await mqtt_adapter.verify_connection()
     if not mqtt_available:
         _LOGGER.warning(
-            "[async_setup_entry] MQTT integration not loaded! "
+            "[async_setup_entry] Lock adapter not available! "
             "PIN codes will NOT be sent to the lock. "
-            "Please configure MQTT in Home Assistant."
+            "Please check your ZHA/MQTT configuration in Home Assistant."
         )
     else:
-        _LOGGER.info("[async_setup_entry] MQTT connection verified successfully")
+        _LOGGER.info("[async_setup_entry] Lock adapter connection verified successfully")
 
     # Store data
     hass.data.setdefault(DOMAIN, {})

--- a/custom_components/nimlykoder/adapters/zha_doorlock.py
+++ b/custom_components/nimlykoder/adapters/zha_doorlock.py
@@ -1,0 +1,96 @@
+"""ZHA adapter for communicating with Nimly locks over the ZCL Door Lock cluster.
+
+Uses direct zigpy cluster calls (set_pin_code / clear_pin_code) instead of the
+deprecated zha.issue_zigbee_cluster_command service, which broke in HA 2024+.
+"""
+from __future__ import annotations
+
+import logging
+
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+
+_LOGGER = logging.getLogger(__name__)
+
+# Nimly locks expose the DoorLock cluster on endpoint 11, not endpoint 1
+# (see zigpy/zha-device-handlers#3095). We try it first, then fall back
+# to scanning all endpoints in case a future firmware/device differs.
+DEFAULT_ENDPOINT_ID = 11
+
+
+class ZhaDoorLockAdapter:
+    """Adapter for communicating with a lock via ZHA's Door Lock cluster."""
+
+    def __init__(self, hass: HomeAssistant, entity_id: str) -> None:
+        self.hass = hass
+        self.entity_id = entity_id
+
+    def _get_door_lock_cluster(self):
+        """Return the zigpy DoorLock cluster for this entity, or None."""
+        from zigpy.zcl.clusters.closures import DoorLock
+
+        if "zha" not in self.hass.config.components:
+            _LOGGER.error("[ZhaDoorLockAdapter] ZHA integration not loaded")
+            return None
+
+        try:
+            from homeassistant.components.zha.helpers import get_zha_gateway_proxy
+
+            gateway = get_zha_gateway_proxy(self.hass)
+            entity_ref = gateway.get_entity_reference(self.entity_id)
+            zigpy_device = entity_ref.entity_data.device_proxy.device.device
+        except Exception as err:
+            _LOGGER.error(
+                "[ZhaDoorLockAdapter] Could not resolve ZHA device for '%s': %s",
+                self.entity_id,
+                err,
+            )
+            return None
+
+        candidate_ids = [DEFAULT_ENDPOINT_ID] + [
+            ep_id for ep_id in zigpy_device.endpoints if ep_id != 0
+        ]
+        for ep_id in candidate_ids:
+            ep = zigpy_device.endpoints.get(ep_id)
+            if ep and DoorLock.cluster_id in ep.in_clusters:
+                return ep.in_clusters[DoorLock.cluster_id]
+
+        _LOGGER.error(
+            "[ZhaDoorLockAdapter] No DoorLock cluster found on '%s'", self.entity_id
+        )
+        return None
+
+    async def add_code(self, slot: int, pin_code: str, user_type: str = "unrestricted") -> None:
+        """Set a PIN code on the lock via the ZCL set_pin_code command."""
+        from zigpy.zcl.clusters.closures import DoorLock
+
+        cluster = self._get_door_lock_cluster()
+        if cluster is None:
+            raise HomeAssistantError(
+                "ZHA DoorLock cluster not available — check that ZHA is running and the lock is paired."
+            )
+        try:
+            await cluster.set_pin_code(
+                slot,
+                DoorLock.UserStatus.Enabled,
+                DoorLock.UserType.Unrestricted,
+                pin_code,
+            )
+        except Exception as err:
+            raise HomeAssistantError(f"Failed to set PIN via ZHA: {err}") from err
+
+    async def remove_code(self, slot: int) -> None:
+        """Clear a PIN code from the lock via the ZCL clear_pin_code command."""
+        cluster = self._get_door_lock_cluster()
+        if cluster is None:
+            raise HomeAssistantError(
+                "ZHA DoorLock cluster not available — check that ZHA is running and the lock is paired."
+            )
+        try:
+            await cluster.clear_pin_code(slot)
+        except Exception as err:
+            raise HomeAssistantError(f"Failed to clear PIN via ZHA: {err}") from err
+
+    async def verify_connection(self) -> bool:
+        """Return True if the DoorLock cluster is reachable via ZHA."""
+        return self._get_door_lock_cluster() is not None


### PR DESCRIPTION
Added a ZHA adapter that talks to the lock directly over the DoorLock cluster. It kicks in automatically if the entity's platform is ZHA or MQTT users see zero difference.

Small diff on purpose: one new adapter file, a few lines in __init__.py to pick the right adapter.
Tested on my own NimlyCodePRO lock — add/remove codes both work.